### PR TITLE
✨ Feat(core) - #18: Adjusted issue titles to use conventional changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-request-feature.md
+++ b/.github/ISSUE_TEMPLATE/component-request-feature.md
@@ -1,7 +1,7 @@
 ---
 name: Component/Request feature
 about: Use this template for a request of adding new features to an existing component.
-title: "[FEAT] "
+title: "feat: ✨ "
 labels: component/change, enhancement, status/triage
 ---
 

--- a/.github/ISSUE_TEMPLATE/component-request-new-component.md
+++ b/.github/ISSUE_TEMPLATE/component-request-new-component.md
@@ -1,7 +1,7 @@
 ---
 name: Component/Request new component
 about: Use this template to request a new component
-title: "[FEAT] "
+title: "feat: ✨ "
 labels: component/new, status/triage, enhancement
 ---
 

--- a/.github/ISSUE_TEMPLATE/generic-bug.md
+++ b/.github/ISSUE_TEMPLATE/generic-bug.md
@@ -1,7 +1,7 @@
 ---
 name: Report a bug
 about: Use this template to report a bug.
-title: "[BUG] "
+title: "fix: 🤔 "
 labels: bug, status/triage
 ---
 

--- a/.github/ISSUE_TEMPLATE/generic-docs.md
+++ b/.github/ISSUE_TEMPLATE/generic-docs.md
@@ -1,0 +1,18 @@
+---
+name: Documentation
+about: Use this template to adjust the documentation.
+title: "docs: 📚 "
+labels: docs, status/triage
+---
+
+**Description**:
+
+<!--
+Please describe what you want to change for the documentation.
+-->
+
+**Rationale**:
+
+<!--
+Please provide a reason for this change to exist.
+-->

--- a/.github/ISSUE_TEMPLATE/generic-feature.md
+++ b/.github/ISSUE_TEMPLATE/generic-feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature
 about: Use this template to request a new feature. Please use "Component/Request feature" for requesting features in new components
-title: "[FEAT] "
+title: "feat: ✨ "
 labels: status/triage, enhancement
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ The following icons are used in commit messages and this changelog.
 
 - #4: Added github action for linting
 - #55: Rename package namespace to `@synergy-design-system`
+- #18: Adjusted issue titles to use [conventional changelog](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type) style.


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adjusts the issue templates to match [conventional changelog](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type) style.

### 🎫 Issues

Closes https://github.com/SickDesignSystem/Internal/issues/18

## 👩‍💻 Reviewer Notes

As discussed, I have added the emojis directly to the issue templates to make them easier to use. If this does not fit our needs, we will remove them at a later point of time.

## ✅ Checklist

### General

- [x] I have updated the project documentation to reflect my changes.
- [x] I have made sure to follow the projects coding and contribution guides.
