### PR TITLE
fix: 🤔 Chromatic treats buttons with spinners as new screenshot every time

### DIFF
--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -2,10 +2,14 @@ import type { Preview } from "@storybook/web-components";
 import '@synergy-design-system/tokens/themes/light.css';
 
 import { setCustomElementsManifest } from '@storybook/web-components';
+
 import '../src/docs.css';
 import '../../tokens/src/shoelace-fallbacks/_utility.css';
 
+import { stopAnimation } from '../src/decorators/StopAnimation';
+
 const preview: Preview = {
+  decorators: [stopAnimation],
   parameters: {
     docs: {
       stories: { inline: false }

--- a/packages/docs/src/decorators/StopAnimation.ts
+++ b/packages/docs/src/decorators/StopAnimation.ts
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { html } from 'lit';
+import type { StoryFn } from '@storybook/web-components';
+import isChromatic from 'chromatic/isChromatic';
+
+/**
+ * Wrap stories with custom disable animation helpers
+ * @param Story The story to apply this to
+ * @param rest Optional parameters
+ * @returns TemplateResult
+ */
+export const stopAnimation = (Story: StoryFn, ...rest: unknown[]) => {
+  // Disable animations when running chromatic.
+  // Can be tested by appending a get parameter chromatic=true / false
+  if (isChromatic()) {
+    return html`
+      <style>
+      :root {
+        --syn-transition-x-fast: -1s !important;
+        --syn-transition-fast: -1s !important;
+        --syn-transition-medium: -1s !important;
+        --syn-transition-slow: -1s !important;
+        --syn-transition-x-slow: -1s !important;
+      }
+      syn-spinner,
+      syn-button::part(spinner) {
+        --speed: -1s !important;
+      }
+      </style>
+      ${Story(...rest)}
+    `;
+  }
+
+  // Return the unaltered story
+  return Story(...rest);
+};


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR removes animations from `<syn-spinner />` when used in chromatic environments. It also tries to do the same by setting the animation timeouts for other animations to `-1`, effectively removing them.

### 🎫 Issues

Closes #133.

## 👩‍💻 Reviewer Notes

- The functionality as described in `packages/docs/src/decorators/StopAnimation.ts` will work, but some components of shoelace bring their own timings, hence the override for `syn-spinner`.

## 📑 Test Plan

- Check out this branch
- Run `pnpm i -r && pnpm build`
- Move to `packages/docs` and start via `pnpm start`
- Open the Story SynButton/Loading (http://localhost:6006/?path=/story/components-syn-button--loading). You should see the spin icon rotates
- Exchange the url for http://localhost:6006/?path=/story/components-syn-button--loading&chromatic=true. With `chromatic=true`, you should now see a frozen loading indicator. (This parameter will be automatically added when running via Chromatic, so it is save to use for testing)

## ✅ Checklist

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
