### PR TITLE
fix: 🐛 fix focus ring offset

### DIFF
--- a/packages/tokens/src/figma-tokens/semantic/input.json
+++ b/packages/tokens/src/figma-tokens/semantic/input.json
@@ -262,11 +262,5 @@
         "type": "fontSizes"
       }
     }
-  },
-  "focus-ring": {
-    "offset": {
-      "value": "0",
-      "type": "spacing"
-    }
   }
 }


### PR DESCRIPTION
This pull request fixes the focus ring offset issue in the code. The previous offset value was set twice, causing the focus ring to be misaligned. This PR updates the offset value to the correct spacing value, ensuring that the focus ring is properly aligned.

Closes #158