### PR TITLE
fix: 🤔 Storybooks play function does not work with custom component in forms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,7 +79,6 @@
         "packages/components/src/internal/default-value.ts": true,
         "packages/components/src/internal/test.ts": true,
         "packages/components/src/styles/form-control.styles.ts": true,
-        "packages/docs/stories/components/textarea.stories.ts": true,
         "packages/docs/stories/components/button.stories.ts": true,
         "packages/docs/stories/components/alert.stories.ts": true,
         "packages/react/src/**": true,

--- a/packages/docs/.eslintrc
+++ b/packages/docs/.eslintrc
@@ -7,6 +7,10 @@
     "project": "./tsconfig.json"
   },
   "rules": {
-    "import/no-extraneous-dependencies": 1
+    // Disabled because this is a private package that does not differenciate between dev and non dev dependencies
+    "import/no-extraneous-dependencies": 0,
+
+    // We have to include our packages in a relative way to make autoreloads work
+    "import/no-relative-packages": 0
   }
 }

--- a/packages/docs/stories/components/checkbox.stories.ts
+++ b/packages/docs/stories/components/checkbox.stories.ts
@@ -1,7 +1,5 @@
-/* eslint-disable */
-
-/* eslint-disable import/no-relative-packages */
-
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type { SynButton, SynCheckbox } from '@synergy-design-system/components';
 import '../../../components/src/components/checkbox/checkbox';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -9,6 +7,7 @@ import { userEvent } from '@storybook/testing-library';
 import { waitUntil } from '@open-wc/testing-helpers';
 import docsTokens from '../../../tokens/src/figma-tokens/_docs.json';
 import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../src/helpers/component.js';
+
 const { args, argTypes } = storybookDefaults('syn-checkbox');
 const { overrideArgs } = storybookHelpers('syn-checkbox');
 const { generateTemplate } = storybookTemplate('syn-checkbox');
@@ -17,65 +16,67 @@ const generateStoryDescription = (attributeName: string) => {
   const story = (docsTokens?.components?.checkbox as Record<string, any>)?.[attributeName]?.description?.value ?? 'No Description';
   return {
     story,
-  }
+  };
 };
 
 const meta: Meta = {
-  component: 'checkbox',
   args: overrideArgs([
-    { name: 'default', type: 'slot', value: 'Checkbox' }
+    { name: 'default', type: 'slot', value: 'Checkbox' },
   ]),
   argTypes,
-  title: 'Components/syn-checkbox',
   parameters: {
     docs: {
       description: generateStoryDescription('default'),
-    }
-  }
+    },
+  },
+  title: 'Components/syn-checkbox',
 };
 export default meta;
 
 type Story = StoryObj;
 
 export const Default = {
-  render: (args: any) => {
-    return generateTemplate({ args });
-  },
   parameters: {
     docs: {
       description: generateStoryDescription('default'),
-    }
-  }
+    },
+  },
+  render: (args: any) => generateTemplate({ args }),
 } as Story;
 
 export const Checked: Story = {
-  render: () => html`<syn-checkbox checked>Checked</syn-checkbox>`,
   parameters: {
     docs: {
       description: generateStoryDescription('checked'),
-    }
-  }
+    },
+  },
+  render: () => html`<syn-checkbox checked>Checked</syn-checkbox>`,
 };
 
 export const Indeterminate: Story = {
-  render: () => html`<syn-checkbox indeterminate>Indeterminate</syn-checkbox>`,
   parameters: {
     docs: {
       description: generateStoryDescription('indeterminate'),
-    }
-  }
+    },
+  },
+  render: () => html`<syn-checkbox indeterminate>Indeterminate</syn-checkbox>`,
 };
 
 export const Disabled: Story = {
-  render: () => html`<syn-checkbox disabled>Disabled</syn-checkbox>`,
   parameters: {
     docs: {
       description: generateStoryDescription('disabled'),
-    }
-  }
+    },
+  },
+  render: () => html`<syn-checkbox disabled>Disabled</syn-checkbox>`,
 };
 
 export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: generateStoryDescription('sizes'),
+    },
+  },
   render: () => html`
     <div style="display: flex; flex-direction: column; gap: 1rem;">
       <syn-checkbox size="small">Small</syn-checkbox>
@@ -83,22 +84,30 @@ export const Sizes: Story = {
       <syn-checkbox size="large">Large</syn-checkbox>
     </div>
   `,
-  parameters: {
-    docs: {
-      description: generateStoryDescription('sizes'),
-    }
-  }
 };
 
 export const CustomValidity: Story = {
+  parameters: {
+    docs: {
+      description: generateStoryDescription('validity'),
+    },
+  },
   play: async ({ canvasElement }) => {
     try {
-      const button = canvasElement.querySelector('button');
+      const form = canvasElement.querySelector('form');
+      const button: SynButton|null = canvasElement.querySelector('syn-button');
+      const checkbox: SynCheckbox|null = canvasElement.querySelector('syn-checkbox');
+      const errorMessage = "Don't forget to check me!";
 
-      await waitUntil(() => customElements.whenDefined('syn-checkbox'));
+      await waitUntil(() => Promise.allSettled([
+        customElements.whenDefined('syn-checkbox'),
+        customElements.whenDefined('syn-button'),
+      ]));
 
-      if (button) {
+      if (form && button && checkbox) {
+        checkbox.setCustomValidity(errorMessage);
         await userEvent.click(button);
+        button.click();
       }
     } catch (error) {
       console.error('Error in play function:', error);
@@ -107,49 +116,31 @@ export const CustomValidity: Story = {
   render: () => html`
     <form class="custom-validity">
       <syn-checkbox name="checked" value="on">Check me</syn-checkbox>
-      <br />
-      <button type="submit">Submit</button>
+      <syn-button type="submit" variant="filled">Submit</syn-button>
     </form>
     <style>
-    form {
-      display: flex;
+    .custom-validity {
+      display: inline-flex;
       flex-direction: column;
-    }
-
-    button {
-      margin-top: 1rem;
-      align-self: flex-start;
-      padding: 0.5rem 1rem;
-      min-width: 5%;
+      gap: 1rem;
     }
     </style>
 
     <script type="module">
-      const form = document.querySelector('.custom-validity');
-      const checkbox = form.querySelector('syn-checkbox');
-      const errorMessage = \`Don't forget to check me!\`;
+    const form = document.querySelector('.custom-validity');
+    const checkbox = form.querySelector('syn-checkbox');
+    const errorMessage = "Don't forget to check me!";
 
-      // Set initial validity as soon as the element is defined
-      customElements.whenDefined('syn-checkbox').then(async () => {
-        await checkbox.updateComplete;
-        checkbox.setCustomValidity(errorMessage);
-      });
+    // Update validity on change
+    checkbox.addEventListener('syn-change', () => {
+      checkbox.setCustomValidity(checkbox.checked ? '' : errorMessage);
+    });
 
-      // Update validity on change
-      checkbox.addEventListener('syn-change', () => {
-        checkbox.setCustomValidity(checkbox.checked ? '' : errorMessage);
-      });
-
-      // Handle submit
-      form.addEventListener('submit', event => {
-        event.preventDefault();
-        alert('All fields are valid!');
-      });
+    // Handle submit
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      alert('All fields are valid!');
+    });
     </script>
   `,
-  parameters: {
-    docs: {
-      description: generateStoryDescription('validity'),
-    }
-  },
 };

--- a/packages/docs/stories/components/input.stories.ts
+++ b/packages/docs/stories/components/input.stories.ts
@@ -1,5 +1,5 @@
-/* eslint-disable import/no-relative-packages */
-
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type { SynButton, SynInput } from '@synergy-design-system/components';
 import '../../../components/src/components/input/input';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -17,7 +17,6 @@ const generateStoryDescription = (attributeName: string) => ({
 });
 
 const meta: Meta = {
-  component: 'input',
   args,
   argTypes,
   parameters: {
@@ -102,8 +101,8 @@ export const Focus: Story = {
     label: 'Label',
     placeholder: 'Insert text here...',
   },
-  play: ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    const input = canvasElement.querySelector('syn-input') as HTMLInputElement;
+  play: ({ canvasElement }) => {
+    const input = canvasElement.querySelector('syn-input') as SynInput;
     if (input) {
       input.focus();
     }
@@ -126,7 +125,7 @@ export const Disabled: Story = {
   render: () => html`
   <syn-input placeholder="Disabled" help-text="Help Text" label="Label" disabled>
     <syn-icon name="house" slot="prefix"></syn-icon>
-    <syn-icon name="chat" slot="suffix">
+    <syn-icon name="chat" slot="suffix"></syn-icon>
   </syn-input>`,
 };
 
@@ -156,42 +155,51 @@ export const Invalid: Story = {
   },
   play: async ({ canvasElement }) => {
     try {
-      const input = canvasElement.querySelector('syn-input');
-      const button = canvasElement.querySelector('button');
+      const form = canvasElement.querySelector('form');
 
-      await waitUntil(() => input?.shadowRoot?.querySelector('input'));
+      if (!form) {
+        return;
+      }
 
-      if (button) {
+      const input = form.querySelector('syn-input') as SynInput;
+      const button = form.querySelector('syn-button') as SynButton;
+
+      await waitUntil(() => Promise.allSettled([
+        customElements.whenDefined('syn-input'),
+        customElements.whenDefined('syn-button'),
+      ]));
+
+      if (button && input) {
         await userEvent.click(button);
+        button.click();
       }
     } catch (error) {
       console.error('Error in play function:', error);
     }
   },
-  render: (args: any) => html`
-  <form>
-   ${generateTemplate({
+  render: (args) => html`
+    <form class="custom-validity">
+  ${generateTemplate({
     args,
-    constants: [
-      { type: 'attribute', name: 'required', value: true },
-    ],
+    constants: [{
+      name: 'required',
+      type: 'attribute',
+      value: true,
+    }],
   })}
-    <button size="medium" type="submit">Submit</button>
-  </form>
-  <style>
-  form {
-    display: flex;
-    flex-direction: column;
-  }
-
-  button {
-    margin-top: 1rem;
-    align-self: flex-end;
-    padding: 0.5rem 1rem;
-    min-width: 5%;
-  }
-  </style>
-`,
+      <syn-button type="submit" variant="filled">Submit</syn-button>
+    </form>
+    <style>
+    .custom-validity {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    syn-button {
+      align-self: flex-start;
+    }
+    </style>
+  `,
 };
 
 /**

--- a/packages/docs/stories/components/textarea.stories.ts
+++ b/packages/docs/stories/components/textarea.stories.ts
@@ -1,5 +1,5 @@
-/* eslint-disable import/no-relative-packages */
-
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type { SynButton, SynTextarea } from '@synergy-design-system/components';
 import '../../../components/src/components/textarea/textarea';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -17,7 +17,6 @@ const generateStoryDescription = (attributeName: string) => ({
 });
 
 const meta: Meta = {
-  component: 'textarea',
   args,
   argTypes,
   parameters: {
@@ -99,8 +98,8 @@ export const Focus: Story = {
   args: {
     placeholder: 'This is in focus',
   },
-  play: ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    const textarea = canvasElement.querySelector('syn-textarea') as HTMLInputElement;
+  play: ({ canvasElement }) => {
+    const textarea = canvasElement.querySelector('syn-textarea') as SynTextarea;
     if (textarea) {
       textarea.focus();
     }
@@ -146,41 +145,51 @@ export const Invalid: Story = {
   parameters: { controls: { exclude: ['required'] } },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     try {
-      const textarea = canvasElement.querySelector('syn-textarea');
-      const button = canvasElement.querySelector('button');
+      const form = canvasElement.querySelector('form');
 
-      await waitUntil(() => textarea?.shadowRoot?.querySelector('textarea'));
+      if (!form) {
+        return;
+      }
 
-      if (button) {
+      const textarea = form.querySelector('syn-textarea') as SynTextarea;
+      const button = form.querySelector('syn-button') as SynButton;
+
+      await waitUntil(() => Promise.allSettled([
+        customElements.whenDefined('syn-textarea'),
+        customElements.whenDefined('syn-button'),
+      ]));
+
+      if (button && textarea) {
         await userEvent.click(button);
+        button.click();
       }
     } catch (error) {
       console.error('Error in play function:', error);
     }
   },
   render: (args: any) => html`
-  <form>
-   ${generateTemplate({
+    <form class="custom-validity">
+  ${generateTemplate({
     args,
-    constants: [
-      { type: 'attribute', name: 'required', value: true },
-    ],
+    constants: [{
+      name: 'required',
+      type: 'attribute',
+      value: true,
+    }],
   })}
-    <button size="medium" type="submit">Submit</button>
-  </form>
-  <style>
-  form {
-    display: flex;
-    flex-direction: column;
-  }
-  button {
-    margin-top: 1rem;
-    align-self: flex-end;
-    padding: 0.5rem 1rem;
-    min-width: 5%;
-  }
-  </style>
-`,
+      <syn-button type="submit" variant="filled">Submit</syn-button>
+    </form>
+    <style>
+    .custom-validity {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    syn-button {
+      align-self: flex-start;
+    }
+    </style>
+  `,
 };
 
 export const PreventResizing: Story = {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that `syn-button` could not be used to submit forms when using Storybooks play functionality.

### 🎫 Issues

Closes #169

## 👩‍💻 Reviewer Notes

- The event utilities of `@testing-library` do not play well with `customElements`. To make it work, I had to rely on the native DOM events (e.g. `button.click()` instead of `userEvent.click(button)`.
- For the sake of portability, I have added both functionalities to make Storybook recognize that a Play-Interaction was available at all.

## 📑 Test Plan

- Run `pnpm i -r && pnpm build` in the root of this branch
- Move to `packages/docs` and start Storybook
- Open http://localhost:6006/?path=/story/components-syn-input--invalid and check if the Required-Error-Message is displayed
- The form should include a `syn-button` with the content **Submit**.
- `Interactions` should show a **1** marker, as there was one automatic story (the `syn-button` was clicked)
- When resetting the interaction, it should show the form as valid
- When running the interaction again, the Error-Message should be shown again.

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
