### PR TITLE
chore: automatically register frameworks changes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,9 +23,12 @@
     "./utilities/*": "./dist/utilities/*",
     "./translations/*": "./dist/translations/*"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "node scripts/build.js",
+    "create-checksums": "node -e 'import(\"./scripts/jobs/createChecksums.js\").then( loadedModule => loadedModule.runCreateChecksums() )'",
     "test": "web-test-runner --group default",
     "vendor": "node scripts/vendorism.js",
     "vendor.get": "node scripts/vendorism.js -g",
@@ -143,7 +146,10 @@
         "@semantic-release/git",
         {
           "message": "chore(release/components): ${nextRelease.version} [skip actions]\n\n${nextRelease.notes}",
-          "assets": ["CHANGELOG.md", "package.json"]
+          "assets": [
+            "CHANGELOG.md",
+            "package.json"
+          ]
         }
       ],
       [
@@ -161,5 +167,11 @@
     "composed-offset-position": "^0.0.4",
     "lit": "^3.0.0"
   },
-  "web-types": "./dist/web-types.json"
+  "web-types": "./dist/web-types.json",
+  "meta": {
+    "checksums": {
+      "angular": "45415e7688194ab65f8f72efe2a27a658910c202",
+      "react": "00bfba6d406eb66250a884de281d565678cc0f0e"
+    }
+  }
 }

--- a/packages/components/scripts/build.js
+++ b/packages/components/scripts/build.js
@@ -36,3 +36,5 @@ await Promise.all([
     componentPackageDir: componentDir,
   }),
 ]);
+
+await jobs.runCreateChecksums();

--- a/packages/components/scripts/jobs/createChecksums.js
+++ b/packages/components/scripts/jobs/createChecksums.js
@@ -1,0 +1,64 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+
+import { job } from './shared.js';
+
+/**
+ * This function will create the events/events.ts file out of all vendored events
+ */
+export const runCreateChecksums = job('Checksums updated in package.json', async () => {
+  function extractShasum(output) {
+    const shasumRegex = /npm notice shasum:\s+([a-f0-9]{40})\s+/i;
+    const match = output.match(shasumRegex);
+
+    if (match && match[1]) {
+      return match[1];
+    }
+
+    throw new Error('Shasum not found in npm publish output');
+  }
+
+  function getChecksum(directory) {
+    // Save the current working directory
+    const originalDirectory = process.cwd();
+
+    // Change to the target directory
+    process.chdir(directory);
+
+    // Run `npm publish --dry-run` and capture the output
+    const output = execSync('npm publish --dry-run 2>&1', { encoding: 'utf-8' });
+
+    // Return to the original directory
+    process.chdir(originalDirectory);
+
+    // Extract and return the shasum
+    return extractShasum(output);
+  }
+
+  function updatePackageJson(checksum, project) {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    // Ensure meta.checksums object exists
+    packageJson.meta = packageJson.meta || {};
+    packageJson.meta.checksums = packageJson.meta.checksums || {};
+
+    // Update the checksum
+    packageJson.meta.checksums[project] = checksum;
+
+    // Write the updated package.json back to disk
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+  }
+
+  try {
+    const angularChecksum = getChecksum('../angular');
+    const reactChecksum = getChecksum('../react');
+
+    await updatePackageJson(angularChecksum, 'angular');
+    await updatePackageJson(reactChecksum, 'react');
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+});

--- a/packages/components/scripts/jobs/index.js
+++ b/packages/components/scripts/jobs/index.js
@@ -6,3 +6,4 @@ export * from './esbuildComponents.js';
 export * from './prepare.js';
 export * from './react.js';
 export * from './tsc.js';
+export * from './createChecksums.js';


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!--
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

1. A `createChecksums` script was added. This automatically creates a dry release of `npm publish` and saves the checksum in components/package.json
2. The script runs automatically at the end of `pnpm build` or on `pnpm create-checksums`. 
3. `pnpm create-checksums` can be used if you make only changes in `angular/package.json` or similar, to just run it faster
4. `pnpm build` is used in the release as well, so after the package.jsons are updated during `semantic-release`

### 🎫 Issues

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
